### PR TITLE
Fix clipping issue

### DIFF
--- a/code/qcommon/cm_trace.c
+++ b/code/qcommon/cm_trace.c
@@ -1500,7 +1500,7 @@ void CM_Trace( trace_t *results, const vec3_t start, const vec3_t end, vec3_t mi
     //
     // check for position test special case
     //
-    if (start[0] == end[0] && start[1] == end[1] && start[2] == end[2]) {
+    if (start[0] == end[0] && start[1] == end[1] && start[2] == end[2] && tw.size[0][0] == 0.0f && tw.size[0][1] == 0.0f && tw.size[0][2] == 0.0f) {
         if ( model && cmod->firstNode == -1 ) {
 #ifdef ALWAYS_BBOX_VS_BBOX // FIXME - compile time flag?
             if ( model == BOX_MODEL_HANDLE || model == CAPSULE_MODEL_HANDLE) {


### PR DESCRIPTION
In SoF2, there is an additional check in the case where start of the trace is equal to the end of the trace (effectively a position test). There's another check done on the half-extents. If the half-extents are 0, then it moves on to sweeping through the world.

Adding the half extents check effectively solves the clipping into walls issue when you're  crouchjumping and releasing crouch at the apex of the jump.