### PR TITLE
Add the player ID into the getstatus message

### DIFF
--- a/code/server/sv_main.c
+++ b/code/server/sv_main.c
@@ -586,8 +586,8 @@ static void SVC_Status( netadr_t from ) {
         cl = &svs.clients[i];
         if ( cl->state >= CS_CONNECTED ) {
             ps = SV_GameClientNum( i );
-            Com_sprintf (player, sizeof(player), "%i %i \"%s\"\n",
-                ps->persistant[PERS_SCORE], cl->ping, cl->name);
+            Com_sprintf (player, sizeof(player), "%i %i %i \"%s\"\n",
+                i, ps->persistant[PERS_SCORE], cl->ping, cl->name);
             playerLength = strlen(player);
             if (statusLength + playerLength >= sizeof(status) ) {
                 break;      // can't hold any more


### PR DESCRIPTION
The getstatus response is missing the player ID. Thanks to that, running a getstatus query on SoF2 Gold for a server running SoF2Plus engine, the player info is incorrect.
![image](https://github.com/user-attachments/assets/7c465668-de9d-4c35-98dc-36523624d152)
This commit adds the player ID into the message as per the original SoF2 Gold response.