### PR TITLE
Append team into the statusResponse message

### DIFF
--- a/code/server/sv_main.c
+++ b/code/server/sv_main.c
@@ -586,8 +586,8 @@ static void SVC_Status( netadr_t from ) {
         cl = &svs.clients[i];
         if ( cl->state >= CS_CONNECTED ) {
             ps = SV_GameClientNum( i );
-            Com_sprintf (player, sizeof(player), "%i %i \"%s\"\n",
-                ps->persistant[PERS_SCORE], cl->ping, cl->name);
+            Com_sprintf (player, sizeof(player), "%i %i %i \"%s\"\n",
+                ps->persistant[PERS_SCORE], cl->ping, ps->persistant[PERS_TEAM], cl->name);
             playerLength = strlen(player);
             if (statusLength + playerLength >= sizeof(status) ) {
                 break;      // can't hold any more


### PR DESCRIPTION
The ```getstatus``` query in SoF2 Gold based on disassembly information has the following structure for client information:
```"%i %i %i \"%s\"\n",```

Upon analysis on what field the 3rd integer points to with Wireshark and a disassembler, I found out that this denotes the current player team. Whilst I haven't seen it in use (at least not in vanilla SoF2MP Gold), it still creates an issue when a client checks getstatus in the server browser:
![image](https://github.com/user-attachments/assets/2d39d902-2ace-43df-a775-a8192e126e9a)

When the team information is appended to the statusResponse, the output is correct:
![image](https://github.com/user-attachments/assets/5785702c-0d1c-475a-915c-c340efe85686)